### PR TITLE
Implémentation des endpoints HTTP pour les observations

### DIFF
--- a/src/main/java/ch/heigvd/Main.java
+++ b/src/main/java/ch/heigvd/Main.java
@@ -1,9 +1,11 @@
 package ch.heigvd;
 
 import ch.heigvd.controllers.AnimalController;
+import ch.heigvd.controllers.ObservationController;
 import ch.heigvd.exceptions.ConflictException;
 import ch.heigvd.exceptions.NotFoundException;
 import ch.heigvd.logic.AnimalLogic;
+import ch.heigvd.logic.ObservationLogic;
 import io.javalin.Javalin;
 
 public class Main {
@@ -11,8 +13,13 @@ public class Main {
 
     public static void main(String[] args) {
 
+        // Logique métier
         AnimalLogic animalLogic = new AnimalLogic();
+        ObservationLogic observationLogic = new ObservationLogic(animalLogic); // ObservationLogic dépend de AnimalLogic
+
+        // Contrôleurs
         AnimalController animalController = new AnimalController(animalLogic);
+        ObservationController observationController = new ObservationController(observationLogic);
 
         Javalin app = Javalin.create();
 
@@ -23,7 +30,14 @@ public class Main {
         app.put("/animals/{number}", animalController::update);
         app.delete("/animals/{number}", animalController::delete);
 
-        // Exception handlers
+        // Routes Observations
+        app.post("/observations", observationController::create);
+        app.get("/observations", observationController::getAll);
+        app.get("/observations/{id}", observationController::getOne);
+        app.put("/observations/{id}", observationController::update);
+        app.delete("/observations/{id}", observationController::delete);
+
+        // Gestion des exceptions
         app.exception(NotFoundException.class, (e, ctx) -> {
             ctx.status(404).json(e.getMessage());
         });
@@ -39,3 +53,4 @@ public class Main {
         app.start(PORT);
     }
 }
+

--- a/src/main/java/ch/heigvd/controllers/ObservationController.java
+++ b/src/main/java/ch/heigvd/controllers/ObservationController.java
@@ -1,0 +1,51 @@
+package ch.heigvd.controllers;
+
+import ch.heigvd.logic.ObservationLogic;
+import ch.heigvd.models.Observation;
+import io.javalin.http.Context;
+
+import java.time.LocalDate;
+
+public class ObservationController {
+
+    private final ObservationLogic logic;
+
+    public ObservationController(ObservationLogic logic) {
+        this.logic = logic;
+    }
+
+    public void create(Context ctx) {
+        Observation observation = ctx.bodyAsClass(Observation.class);
+        Observation created = logic.create(observation);
+        ctx.status(201).json(created);
+    }
+
+    public void getAll(Context ctx) {
+        String animalParam = ctx.queryParam("animalNumber");
+        String dateParam = ctx.queryParam("date");
+        String region = ctx.queryParam("region");
+
+        Integer animalNumber = animalParam != null ? Integer.parseInt(animalParam) : null;
+
+        LocalDate date = dateParam != null ? LocalDate.parse(dateParam) : null;
+
+        ctx.json(logic.getAll(animalNumber, date, region));
+    }
+
+    public void getOne(Context ctx) {
+        int id = Integer.parseInt(ctx.pathParam("id"));
+        ctx.json(logic.getOne(id));
+    }
+
+    public void update(Context ctx) {
+        int id = Integer.parseInt(ctx.pathParam("id"));
+        Observation observation = ctx.bodyAsClass(Observation.class);
+        ctx.json(logic.update(id, observation));
+    }
+
+    public void delete(Context ctx) {
+        int id = Integer.parseInt(ctx.pathParam("id"));
+        logic.delete(id);
+        ctx.status(204);
+    }
+}


### PR DESCRIPTION
## Ce qui a été ajouté

API et couche controller :

- Ajout d'un `ObservationController` pour gérer tous les endpoints HTTP liés aux observations, notamment les opérations de création, de lecture, de mise à jour et de suppression. Le contrôleur délègue la logique métier à la classe `ObservationLogic`.

- Mise à jour de `Main.java` pour enregistrer les nouveaux endpoints des observations.