### PR TITLE
Gestion de la concurrence

### DIFF
--- a/src/main/java/ch/heigvd/logic/AnimalLogic.java
+++ b/src/main/java/ch/heigvd/logic/AnimalLogic.java
@@ -3,13 +3,17 @@ package ch.heigvd.logic;
 import ch.heigvd.exceptions.NotFoundException;
 import ch.heigvd.models.Animal;
 import ch.heigvd.models.AnimalGroup;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import java.util.*;
 
 public class AnimalLogic {
 
-    private final Map<Integer, Animal> animals = new HashMap<>();
-    private int counter = 1;
+    private final Map<Integer, Animal> animals = new ConcurrentHashMap<>();
+    private final AtomicInteger counter = new AtomicInteger(1);
 
     public Animal create(Animal animal) {
 
@@ -18,7 +22,7 @@ public class AnimalLogic {
             throw new IllegalArgumentException("Invalid animal");
         }
 
-        animal.setNumber(counter++);
+        animal.setNumber(counter.getAndIncrement()); // Attribution d'un numéro unique
         animals.put(animal.getNumber(), animal); // Stockage du nouvel animal dans la map
         return animal;
     }

--- a/src/main/java/ch/heigvd/logic/ObservationLogic.java
+++ b/src/main/java/ch/heigvd/logic/ObservationLogic.java
@@ -2,17 +2,17 @@ package ch.heigvd.logic;
 
 import ch.heigvd.exceptions.NotFoundException;
 import ch.heigvd.models.Observation;
-
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class ObservationLogic {
 
-    private final Map<Integer, Observation> observations = new HashMap<>();
-    private int counter = 1;
+    private final Map<Integer, Observation> observations = new ConcurrentHashMap<>();
+    private final AtomicInteger counter = new AtomicInteger(1);
 
     // Dépendance vers AnimalLogic
     private final AnimalLogic animalLogic;
@@ -29,7 +29,7 @@ public class ObservationLogic {
             throw new IllegalArgumentException("Invalid date");
         }
 
-        observation.setId(counter++);
+        observation.setId(counter.getAndIncrement()); // Attribution d'un ID unique
         observations.put(observation.getId(), observation); // Stockage de la nouvelle observation dans la map
         return observation;
     }


### PR DESCRIPTION
## Ce qui a été ajouté

Cette PR permet de rendre l’application résiliente aux accès concurrents. Les principaux changements consistent à remplacer les `HashMap` et les compteurs entiers classiques par des structures de données concurrentes et des compteurs atomiques.

Structures concurrentes et attribution d'identifiants uniques :

- Remplacement de `HashMap` par `ConcurrentHashMap` dans `AnimalLogic`, et conversion du compteur entier en `AtomicInteger` pour une attribution d'identifiants sécurisée dans les threads.

- Remplacement de `HashMap` par `ConcurrentHashMap` dans `ObservationLogic`, et conversion du compteur entier en `AtomicInteger` pour une attribution d'identifiants sécurisée dans les threads.