### PR TITLE
Correction problème de concurrence dans AnimalLogic

### DIFF
--- a/src/main/java/ch/heigvd/logic/AnimalLogic.java
+++ b/src/main/java/ch/heigvd/logic/AnimalLogic.java
@@ -59,12 +59,14 @@ public class AnimalLogic {
     }
 
     public Animal update(int number, Animal animal) {
-        if (!animals.containsKey(number)) {
-            throw new NotFoundException("Animal not found");
+        if (animal.getFrenchName() == null || animal.getLatinName() == null || animal.getGroup() == null) {
+            throw new IllegalArgumentException("Invalid animal");
         }
 
         animal.setNumber(number);
-        animals.put(number, animal); // Mise à jour de l'animal dans la map
+        if (animals.replace(number, animal) == null) {
+            throw new NotFoundException("Animal not found");
+        }
         return animal;
     }
 

--- a/src/main/java/ch/heigvd/logic/ObservationLogic.java
+++ b/src/main/java/ch/heigvd/logic/ObservationLogic.java
@@ -66,15 +66,17 @@ public class ObservationLogic {
     }
 
     public Observation update(int id, Observation observation) {
-        if (!observations.containsKey(id)) {
-            throw new NotFoundException("Observation not found");
+        if (observation.getDate() == null) {
+            throw new IllegalArgumentException("Invalid date");
         }
 
         // Vérifier que l'animal existe
         animalLogic.getOne(observation.getAnimalNumber());
 
         observation.setId(id);
-        observations.put(id, observation); // Mise à jour de l'observation dans la map
+        if (observations.replace(id, observation) == null) {
+            throw new NotFoundException("Observation not found");
+        }
         return observation;
     }
 


### PR DESCRIPTION
Cette PR renforce la résilience concurrente des opérations CRUD :

Remplace le pattern non atomique containsKey() + put() dans update() par ConcurrentHashMap.replace(), qui est atomique.

Aligne la validation update() avec create() :

Animal : frenchName, latinName, group obligatoires

Observation : date obligatoire + vérification que l’animal existe